### PR TITLE
Send confirmation email to reporter when a report is submitted

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,13 +1,13 @@
 class ReportsController < ApplicationController
-  
+
   layout "backstage",                       only: [ :index, :show ]
-  
+
   before_action :authenticate_user!,        only: [ :index, :show, :dismiss, :undismiss ]
   before_action :ensure_staff,              only: [ :index, :show, :dismiss, :undismiss ]
   before_action :find_report,               only: [ :show, :dismiss, :undismiss ]
   before_action :find_reported_twitch_user, only: [ :show ]
   around_action :display_timezone
-  
+
   def index
     # f is used to filter reports by scope
     if params[:f].present? && Report::AVAILABLE_SCOPES.key?(params[:f].to_sym)
@@ -19,7 +19,7 @@ class ReportsController < ApplicationController
       @filter_category = "unresolved"
     end
   end
-  
+
   def show
     # Create keybot advice message
     if @reported_twitch_user == nil
@@ -29,30 +29,32 @@ class ReportsController < ApplicationController
     else
       @message = "The reported Twitch user did not sign the pledge."
     end
-    
+
     # TODO: check if reporter has pledged (lookup email/Twitch name) and add info to keybot message
     # TODO: check if incident stream owner has pledged (Twitch name) and add info to keybot message
 
   end
-  
+
   def new
     @report = Report.new
   end
 
   def create
     @report = Report.new(report_params)
-  
+
     if @report.save
       # Email notification to staff
       StaffMailer.notify_staff_new_report(@report).deliver_now
-      
+      # Email confirmation to reporter
+      PledgeMailer.confirm_reporter(@report).deliver_now
+
       flash[:notice] = "You've successfully submitted the report. Thank you."
       redirect_to root_path
-    else      
+    else
       flash.now[:alert] ||= ""
       @report.errors.full_messages.each do |message|
         flash.now[:alert] << message + ". "
-      end      
+      end
       render(action: :new)
     end
   end
@@ -65,14 +67,14 @@ class ReportsController < ApplicationController
     end
     redirect_to reports_path
   end
-  
+
   def undismiss
     @report.dismissed = false
     @report.reviewer = nil
     if @report.save
       flash[:notice] = "You undismissed the report about #{@report.reported_twitch_name}. It can now be reviewed again."
       redirect_to report_path(@report)
-    else    
+    else
       redirect_to reports_path
     end
   end
@@ -83,11 +85,11 @@ class ReportsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       redirect_to staff_index_path
     end
-    
+
     def find_reported_twitch_user
       # Check if reported_twitch_name exists on Twitch
       response = HTTParty.get(URI.escape("#{ENV['TWITCH_API_BASE_URL']}/users?login=#{@report.reported_twitch_name}"), headers: {"Client-ID": ENV['TWITCH_CLIENT_ID'], "Authorization": "Bearer #{TwitchToken.first.valid_token!}"})
-      
+
       if response["data"].blank?
        @reported_twitch_user = nil
       else
@@ -95,20 +97,20 @@ class ReportsController < ApplicationController
       end
     end
 
-  private          
+  private
     def ensure_staff
       unless current_user.is_moderator? || current_user.is_admin?
         redirect_to root_url
       end
     end
-    
+
     def display_timezone
       timezone = Time.find_zone( cookies[:browser_timezone] )
       Time.use_zone(timezone) { yield }
     end
-    
+
     def report_params
       params.require(:report).permit(:reporter_email, :reporter_twitch_name, :reported_twitch_name, :incident_stream, :incident_occurred, :incident_description, :recommended_response, :image)
     end
-  
+
 end

--- a/app/mailers/pledge_mailer.rb
+++ b/app/mailers/pledge_mailer.rb
@@ -1,35 +1,40 @@
 class PledgeMailer < ApplicationMailer
-  
+
   default from: DO_NOT_REPLY
 
   def welcome_pledger(pledge)
     @pledge = pledge
     mail(to: pledge.email, subject: "Thank you for taking the GLHF pledge!")
   end
-  
+
   def send_pledger_referral(pledge)
     @pledge = pledge
     mail(to: pledge.email, subject: "Your GLHF pledge referral link")
   end
-  
+
   def warn_pledger(warning)
     @warning = warning
     mail(to: warning.pledge.email, subject: "Warning about your conduct")
   end
-  
+
   def revoke_pledger(revocation)
     @revocation = revocation
     mail(to: revocation.pledge.email, subject: "Your AnyKey badge has been revoked")
   end
-  
+
   def notify_reporter_warning(warning)
     @warning = warning
     mail(to: warning.report.reporter_email, subject: "We've acted on your report")
   end
-  
+
   def notify_reporter_revocation(revocation)
     @revocation = revocation
     mail(to: revocation.report.reporter_email, subject: "We've acted on your report")
   end
-  
+
+  def confirm_reporter(report)
+    @report = report
+    mail(to: report.reporter_email, subject: "Badge abuse report submission confirmed")
+  end
+
 end

--- a/app/views/pledge_mailer/confirm_reporter.html.erb
+++ b/app/views/pledge_mailer/confirm_reporter.html.erb
@@ -1,0 +1,7 @@
+Hey friend,
+<br><br>
+Thank you for submitting your report regarding <%= @report.reported_twitch_name %>'s conduct in <%= @report.incident_stream %>'s stream<%= @report.incident_occurred.blank? ? '' : ' on ' + l(@report.incident_occurred, format: "%b. %-d, %Y") %>.
+<br><br>
+Our moderation team will review the incident and we will send you an update once we take an action.
+<br><br>
+We very much appreciate that you spoke up about what you witnessed. Thanks for taking a stand against harassment and discrimination!

--- a/app/views/pledge_mailer/confirm_reporter.text.erb
+++ b/app/views/pledge_mailer/confirm_reporter.text.erb
@@ -1,0 +1,7 @@
+Hey friend,
+
+Thank you for submitting your report regarding <%= @report.reported_twitch_name %>'s conduct in <%= @report.incident_stream %>'s stream<%= @report.incident_occurred.blank? ? '' : ' on ' + l(@report.incident_occurred, format: "%b. %-d, %Y") %>.
+
+Our moderation team will review the incident and we will provide you an update once we take an action on the report.
+
+We very much appreciate that you spoke up about what you witnessed. Thanks for taking a stand against harassment and discrimination!

--- a/db/migrate/20190904053235_change_desired_outcome_to_recommended_response.rb
+++ b/db/migrate/20190904053235_change_desired_outcome_to_recommended_response.rb
@@ -1,5 +1,0 @@
-class ChangeDesiredOutcomeToRecommendedResponse < ActiveRecord::Migration[6.0]
-  def change
-     rename_column :reports, :desired_outcome, :recommended_response
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_23_190839) do
+ActiveRecord::Schema.define(version: 2022_06_30_164320) do
 
   create_table "affiliates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci", force: :cascade do |t|
     t.string "name"
@@ -27,6 +27,15 @@ ActiveRecord::Schema.define(version: 2022_02_23_190839) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "discord"
     t.string "mixer"
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci", force: :cascade do |t|
+    t.integer "report_id"
+    t.integer "commenter_id"
+    t.text "body"
+    t.integer "parent_comment_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "conduct_warnings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci", force: :cascade do |t|
@@ -55,6 +64,7 @@ ActiveRecord::Schema.define(version: 2022_02_23_190839) do
     t.datetime "twitch_authed_on"
     t.integer "referrer_id"
     t.integer "referrals_count", default: 0
+    t.integer "reports_count"
   end
 
   create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci", force: :cascade do |t|
@@ -72,6 +82,7 @@ ActiveRecord::Schema.define(version: 2022_02_23_190839) do
     t.boolean "dismissed", default: false
     t.boolean "warned", default: false
     t.boolean "revoked", default: false
+    t.integer "twitch_id"
     t.index ["reviewer_id"], name: "index_reports_on_reviewer_id"
   end
 
@@ -96,7 +107,7 @@ ActiveRecord::Schema.define(version: 2022_02_23_190839) do
     t.datetime "published_on"
   end
 
-  create_table "twitch_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "twitch_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci", force: :cascade do |t|
     t.string "access_token"
     t.integer "expires_in"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
This PR will send an email confirmation to the reporter once the report is submitted. As doing moderation, I've noticed that we have received suggestions from our reporters that we send a confirmation email.