### PR TITLE
Verification System Improvements

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -13,7 +13,7 @@ function setupCommentSubmitListener() {
     // Intercept click and release button from focus state
     e.preventDefault();
     $('#comment_submit').blur();
-
+    
     $.ajax({
       type: 'POST',
       data: new FormData(this),

--- a/app/assets/javascripts/watchable-panel.js
+++ b/app/assets/javascripts/watchable-panel.js
@@ -1,33 +1,20 @@
 // Toggles status for watchable items
 
 function setupWatchableToggleListener() {
+  $('#watchable-toggle').off('click');
   $('#watchable-toggle').click(function(e) {
-    
+  
     // Intercept click
     e.preventDefault();
-    
-    var url = '';
-    
-    // Determine which endpoint to use
-    if ($(this).hasClass('watched')) {
-      url = $(this).data('watched-url');
-    } else {
-      url = $(this).data('unwatched-url');
-    }
     
     $.ajax({
       type: 'POST',
       processData: false,
       contentType: false,
-      url: url,
-      success: function(data, textStatus, jqXHR) {
-        // Change the button
-        $('#watchable-toggle').attr("class", data["watched_status"]);
-      },
-      error: function(jqXHR, textStatus, errorThrown) {
-        // Do nothing
-      }
+      dataType: 'script',
+      url: this.href
     });
+
   }); 
 }
 

--- a/app/assets/stylesheets/backstage.css
+++ b/app/assets/stylesheets/backstage.css
@@ -134,9 +134,12 @@
 }
 
 #backstage-container .panel-filters a.selected {
-  padding-right: 0em;
   font-weight: 700;
   color: var(--light-black-color);
+}
+
+#backstage-container .panel-filters a.selected.togglable {
+  padding-right: 0em;
 }
 
 #backstage-container .panel-filters a.ordering {

--- a/app/assets/stylesheets/backstage.css
+++ b/app/assets/stylesheets/backstage.css
@@ -127,15 +127,21 @@
 }
 
 #backstage-container .panel-filters a {
-  margin-top: 0.5em;
-  margin-left: 0.5em;
-  margin-right: 0.5em;
-  margin-bottom: 0.5em;
+  padding-top: 0.5em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  padding-bottom: 0.5em;
 }
 
 #backstage-container .panel-filters a.selected {
+  padding-right: 0em;
   font-weight: 700;
-  color: var(--light-black-color); 
+  color: var(--light-black-color);
+}
+
+#backstage-container .panel-filters a.ordering {
+  color: var(--light-black-color);
+  font-family: var(--solid-icon-font);
 }
 
 #backstage-container .panel-filters a:hover {

--- a/app/assets/stylesheets/backstage.css
+++ b/app/assets/stylesheets/backstage.css
@@ -214,6 +214,48 @@
 
 
 /************************************/
+/*   Backstage Queue Status Colors  */
+/************************************/
+
+#backstage-container .record-row .commented {
+  font-size: 0.75em;
+  font-family: var(--solid-icon-font);
+  color: var(--bright-blue-color);
+  margin-left: 0.5em;
+  margin-right: 0.1em;
+}
+
+#backstage-container .record-row .watched {
+  font-size: 0.9em;
+  font-family: var(--solid-icon-font);
+  color: var(--bright-fuchsia-color);
+  margin-left: 0.4em;
+}
+
+#backstage-container .record-row .row-detail.dismissed {
+  font-weight: 700;
+  color: var(--gray-color);
+}
+
+#backstage-container .record-row .row-detail.ignored {
+  font-weight: 700;
+  color: var(--bright-orange-color);
+}
+
+#backstage-container .record-row .row-detail.eligible,
+#backstage-container .record-row .row-detail.reviewed {
+ font-weight: 700;
+ color: var(--bright-green-color);
+}
+
+#backstage-container .record-row .row-detail.denied,
+#backstage-container .record-row .row-detail.withdrawn  {
+  font-weight: 700;
+  color: var(--alert-red-color);
+}
+
+
+/************************************/
 /*         Backstage Search         */
 /************************************/
 

--- a/app/assets/stylesheets/concerns.css
+++ b/app/assets/stylesheets/concerns.css
@@ -8,36 +8,6 @@
 
 
 /************************************/
-/*      Backstage Concern Queue     */
-/************************************/
-
-#backstage-container .record-row .row-detail.dismissed {
-  font-weight: 700;
-  color: var(--gray-color);
-}
-
-#backstage-container .record-row .row-detail.reviewed {
-  font-weight: 700;
-  color: var(--bright-green-color);
-}
-
-#backstage-container .record-row .commented {
-  font-size: 0.75em;
-  font-family: var(--solid-icon-font);
-  color: var(--bright-blue-color);
-  margin-left: 0.5em;
-  margin-right: 0.1em;
-}
-
-#backstage-container .record-row .watched {
-  font-size: 0.9em;
-  font-family: var(--solid-icon-font);
-  color: var(--bright-fuchsia-color);
-  margin-left: 0.4em;
-}
-
-
-/************************************/
 /*     Backstage Concern Review     */
 /************************************/
 

--- a/app/assets/stylesheets/verifications.css
+++ b/app/assets/stylesheets/verifications.css
@@ -174,6 +174,17 @@
   margin-bottom: 0.2em;
 }
 
+#backstage-container .verification-item .item-title.large {
+  font-weight: 600;
+  font-size: 1.1em;
+}
+
+#backstage-container .verification-item .item-title .icon {
+  position: relative;
+  font-family: var(--solid-icon-font);
+  margin-right: 0.3em;
+}
+
 #backstage-container .verification-item .item-text {
   font-size: 1em;
 }

--- a/app/assets/stylesheets/verifications.css
+++ b/app/assets/stylesheets/verifications.css
@@ -155,27 +155,6 @@
 
 
 /************************************/
-/*   Backstage Verification Queue   */
-/************************************/
-
-#backstage-container .record-row .row-detail.ignored {
-  font-weight: 700;
-  color: var(--bright-orange-color);
-}
-
-#backstage-container .record-row .row-detail.eligible {
- font-weight: 700;
- color: var(--bright-green-color);
-}
-
-#backstage-container .record-row .row-detail.denied,
-#backstage-container .record-row .row-detail.withdrawn  {
-  font-weight: 700;
-  color: var(--alert-red-color);
-}
-
-
-/************************************/
 /*  Backstage Verification Review   */
 /************************************/
 

--- a/app/controllers/concerns_controller.rb
+++ b/app/controllers/concerns_controller.rb
@@ -95,20 +95,18 @@ class ConcernsController < ApplicationController
   end
   
   def watch
-    respond_to :json
-    if @concern.update(watched: true)
-      render :json => { watched_status: "watched" }, :status => 200
-    else
-      render :json => {:error => 'An unexpected error occurred', :code => '500'}, :status => 500
+    respond_to do |format|
+      if @concern.update(watched: true)
+        format.js
+      end
     end
   end
 
   def unwatch
-    respond_to :json
-    if @concern.update(watched: false)
-      render :json => { watched_status: "unwatched" }, :status => 200
-    else
-      render :json => {:error => 'An unexpected error occurred', :code => '500'}, :status => 500
+    respond_to do |format|
+      if @concern.update(watched: false)
+        format.js
+      end
     end
   end
   

--- a/app/controllers/concerns_controller.rb
+++ b/app/controllers/concerns_controller.rb
@@ -16,21 +16,28 @@ class ConcernsController < ApplicationController
     else
       per_page = 30
     end
-
+    
     # f is used to filter reports by scope
     # q is used to search for keywords
-    if (params[:f].present? && Concern::SORT_FILTERS.key?(params[:f].to_sym)) && params[:q].present?
-      @concerns = eval("Concern."+params[:f]+".search('"+params[:q]+"').order(shared_on: :asc).paginate(page: params[:page], per_page: "+per_page.to_s+")")
-      @filter_category = params[:f]
-    elsif params[:f].present? && Concern::SORT_FILTERS.key?(params[:f].to_sym)
-      @concerns = eval("Concern."+params[:f]+".order(shared_on: :asc).paginate(page: params[:page], per_page: "+per_page.to_s+")")
+    # o is used to toggle ordering
+    if params[:f].present? && Concern::SORT_FILTERS.key?(params[:f].to_sym)
       @filter_category = params[:f]
     elsif params[:q].present?
-      @concerns = Concern.all.search(params[:q]).order(shared_on: :asc).paginate(page: params[:page], per_page: per_page)
       @filter_category = "all"
     else
-      @concerns = Concern.open.order(shared_on: :asc).paginate(page: params[:page], per_page: per_page)
       @filter_category = "open"
+    end
+    
+    if params[:o].present? && params[:o] == "desc"
+      @ordering = "desc"
+    else
+      @ordering = "asc"
+    end
+    
+    if params[:q].present?
+      @concerns = eval("Concern.#{@filter_category}.search('#{params[:q]}').order(shared_on: :#{@ordering}).paginate(page: params[:page], per_page: #{per_page.to_s})")
+    else
+      @concerns = eval("Concern.#{@filter_category}.order(shared_on: :#{@ordering}).paginate(page: params[:page], per_page: #{per_page.to_s})")
     end
   end
 

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -2,9 +2,14 @@ class VerificationsController < ApplicationController
 
   layout "backstage",                only: [ :index, :show, :verify_eligibility, :deny_eligibility, :withdraw_eligibility ]
   
-  before_action :authenticate_user!, only: [ :index, :show, :verify_eligibility, :deny_eligibility, :withdraw_eligibility, :verify, :deny, :ignore, :withdraw, :voucher, :resend_cert ]
-  before_action :ensure_staff,       only: [ :index, :show, :verify_eligibility, :deny_eligibility, :withdraw_eligibility, :verify, :deny, :ignore, :withdraw, :voucher, :resend_cert ]
-  before_action :find_verification,  only: [ :show, :verify_eligibility, :deny_eligibility, :withdraw_eligibility, :verify, :deny, :ignore, :withdraw, :voucher, :resend_cert ]
+  skip_before_action :verify_authenticity_token, only: [ :watch, :unwatch ]
+  
+  before_action :authenticate_user!, only: [ :index, :show, :verify_eligibility, :deny_eligibility, :withdraw_eligibility,
+                                            :verify, :deny, :ignore, :withdraw, :voucher, :resend_cert, :watch, :unwatch ]
+  before_action :ensure_staff,       only: [ :index, :show, :verify_eligibility, :deny_eligibility, :withdraw_eligibility,
+                                            :verify, :deny, :ignore, :withdraw, :voucher, :resend_cert, :watch, :unwatch ]
+  before_action :find_verification,  only: [ :show, :verify_eligibility, :deny_eligibility, :withdraw_eligibility,
+                                            :verify, :deny, :ignore, :withdraw, :voucher, :resend_cert, :watch, :unwatch ]
   around_action :display_timezone
   
   def index
@@ -170,7 +175,23 @@ class VerificationsController < ApplicationController
     end
     redirect_to verifications_path
   end
+  
+  def watch
+    respond_to do |format|
+      if @verification.update(watched: true)
+        format.js
+      end
+    end
+  end
 
+  def unwatch
+    respond_to do |format|
+      if @verification.update(watched: false)
+        format.js
+      end
+    end
+  end
+  
   protected
     def find_verification
       @verification = Verification.find_by(identifier: params[:id])

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -19,21 +19,28 @@ class VerificationsController < ApplicationController
     else
       per_page = 30
     end
-
+    
     # f is used to filter reports by scope
     # q is used to search for keywords
-    if (params[:f].present? && Verification::SORT_FILTERS.key?(params[:f].to_sym)) && params[:q].present?
-      @verifications = eval("Verification."+params[:f]+".search('"+params[:q]+"').order(requested_on: :asc).paginate(page: params[:page], per_page: "+per_page.to_s+")")
-      @filter_category = params[:f]
-    elsif params[:f].present? && Verification::SORT_FILTERS.key?(params[:f].to_sym)
-      @verifications = eval("Verification."+params[:f]+".order(requested_on: :asc).paginate(page: params[:page], per_page: "+per_page.to_s+")")
+    # o is used to toggle ordering
+    if params[:f].present? && Verification::SORT_FILTERS.key?(params[:f].to_sym)
       @filter_category = params[:f]
     elsif params[:q].present?
-      @verifications = Verification.all.search(params[:q]).order(requested_on: :asc).paginate(page: params[:page], per_page: per_page)
       @filter_category = "all"
     else
-      @verifications = Verification.pending.order(requested_on: :asc).paginate(page: params[:page], per_page: per_page)      
       @filter_category = "pending"
+    end
+    
+    if params[:o].present? && params[:o] == "desc"
+      @ordering = "desc"
+    else
+      @ordering = "asc"
+    end
+    
+    if params[:q].present?
+      @verifications = eval("Verification.#{@filter_category}.search('#{params[:q]}').order(requested_on: :#{@ordering}).paginate(page: params[:page], per_page: #{per_page.to_s})")
+    else
+      @verifications = eval("Verification.#{@filter_category}.order(requested_on: :#{@ordering}).paginate(page: params[:page], per_page: #{per_page.to_s})")
     end
   end
 

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -18,6 +18,7 @@ class Verification < ApplicationRecord
     denied:           "Denied",
     withdrawn:        "Withdrawn",
     eligible:         "Eligible",
+    watched:          "Watched",    
     all:              "All"
   }.freeze
   
@@ -64,6 +65,7 @@ class Verification < ApplicationRecord
   scope :denied,          lambda { where(status: :denied) }
   scope :withdrawn,       lambda { where(status: :withdrawn) }
   scope :eligible,        lambda { where(status: :eligible) }
+  scope :watched,         lambda { where(watched: true) }  
   scope :search,          lambda { |search| where("lower(first_name) LIKE :search OR
                                                    lower(last_name) LIKE :search OR
                                                    lower(email) LIKE :search OR

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -55,7 +55,9 @@ class Verification < ApplicationRecord
   
   has_one_attached :photo_id
   has_one_attached :doctors_note
-    
+  
+  has_many :comments, as: :commentable
+  
   # Non-sequential identifier scheme
   uniquify :identifier, length: 8, chars: ('A'..'Z').to_a + ('0'..'9').to_a
 

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -121,15 +121,16 @@ class Verification < ApplicationRecord
   end
   
   def related_requests
-    # Search for each of self's parameters aggregating results
+    # Search across the same fields for each of self's parameters aggregating results
     # Sort by most frequent matches across paramaters
     # Return ordered collection of uniques
-    reqs = (Verification.where.not(id: self.id).search(self.email) +
-            Verification.where.not(id: self.id).search(self.first_name) +
-            Verification.where.not(id: self.id).search(self.last_name) +
-            Verification.where.not(id: self.id).search(self.discord_username) +
-            Verification.where.not(id: self.id).search(self.player_id))
-
+    
+    reqs = (Verification.where.not(id: self.id).where("lower(email) LIKE '%#{self.email.downcase}%'") +
+            Verification.where.not(id: self.id).where("lower(first_name) LIKE '%#{self.first_name.downcase}%'") +
+            Verification.where.not(id: self.id).where("lower(last_name) LIKE '%#{self.last_name.downcase}%'") +
+            Verification.where.not(id: self.id).where("lower(discord_username) LIKE '%#{self.discord_username.downcase}%'") +
+            Verification.where.not(id: self.id).where("lower(player_id) LIKE '%#{self.player_id.downcase}%'"))
+    
     reqs.uniq.sort_by { |e| -reqs.count(e)}
   end
 

--- a/app/views/concerns/_show_dismissed.html.erb
+++ b/app/views/concerns/_show_dismissed.html.erb
@@ -6,7 +6,7 @@
     <div class="panel-descriptor">
       Dismissed <%= l(@concern.reviewed_on, format: "%b. %-d, %Y · %-l:%M%P") %> [<%= link_to(@concern.reviewer.display_name, user_path(@concern.reviewer)) %>]
     </div>
-    <%= link_to('&#xf06e;'.html_safe, '', data: {watched_url: unwatch_concern_path(@concern), unwatched_url: watch_concern_path(@concern)}, id: "watchable-toggle", class: @concern.watched ? 'watched' : 'unwatched') %>
+    <%= render(partial: "concerns/watchable_toggle")%>
   </div>
 </div>
 <%= render(partial: "concerns/body") %>

--- a/app/views/concerns/_show_open.html.erb
+++ b/app/views/concerns/_show_open.html.erb
@@ -6,7 +6,7 @@
     <div class="panel-descriptor">
       Shared <%= l(@concern.shared_on, format: "%b. %-d, %Y · %-l:%M%P") %>
     </div>
-    <%= link_to('&#xf06e;'.html_safe, '', data: {watched_url: unwatch_concern_path(@concern), unwatched_url: watch_concern_path(@concern)}, id: "watchable-toggle", class: @concern.watched ? 'watched' : 'unwatched') %>
+    <%= render(partial: "concerns/watchable_toggle")%>
   </div>
 </div>
 <%= render(partial: "concerns/body") %>

--- a/app/views/concerns/_show_reviewed.html.erb
+++ b/app/views/concerns/_show_reviewed.html.erb
@@ -6,7 +6,7 @@
     <div class="panel-descriptor">
       Reviewed <%= l(@concern.reviewed_on, format: "%b. %-d, %Y · %-l:%M%P") %> [<%= link_to(@concern.reviewer.display_name, user_path(@concern.reviewer)) %>]
     </div>
-    <%= link_to('&#xf06e;'.html_safe, '', data: {watched_url: unwatch_concern_path(@concern), unwatched_url: watch_concern_path(@concern)}, id: "watchable-toggle", class: @concern.watched ? 'watched' : 'unwatched') %>
+    <%= render(partial: "concerns/watchable_toggle")%>
   </div>
 </div>
 <%= render(partial: "concerns/body") %>

--- a/app/views/concerns/_watchable_toggle.html.erb
+++ b/app/views/concerns/_watchable_toggle.html.erb
@@ -1,0 +1,1 @@
+<%= link_to('&#xf06e;'.html_safe, @concern.watched ? unwatch_concern_path(@concern) : watch_concern_path(@concern), id: "watchable-toggle", class: @concern.watched ? 'watched' : 'unwatched') %>

--- a/app/views/concerns/index.html.erb
+++ b/app/views/concerns/index.html.erb
@@ -19,9 +19,11 @@
           <% Concern::SORT_FILTERS.each do |filter| %>
             <% if @filter_category.to_s == filter[0].to_s %>
               <% if params[:q].present? %>
-                <%= link_to("#{filter[1]} [#{@concerns.nil? ? '0' : @concerns.count}]", concerns_path(q: params[:q], f: filter[0]), class: "filter selected") %>
+                <%= link_to("#{filter[1]} [#{@concerns.nil? ? '0' : @concerns.count}]", concerns_path(q: params[:q], f: filter[0]), class: "filter selected togglable") %>
+                <%= link_to(@ordering == "asc" ? "&#xf309;".html_safe : "&#xf30c;".html_safe, concerns_path(q: params[:q], f: filter[0], o: @ordering == "asc" ? "desc" : "asc"), class: "ordering") %>
               <% else %>
-                <%= link_to("#{filter[1]} [#{@concerns.nil? ? '0' : @concerns.count}]", concerns_path(f: filter[0]), class: "filter selected") %>            
+                <%= link_to("#{filter[1]} [#{@concerns.nil? ? '0' : @concerns.count}]", concerns_path(f: filter[0]), class: "filter selected togglable") %>
+                <%= link_to(@ordering == "asc" ? "&#xf309;".html_safe : "&#xf30c;".html_safe, concerns_path(f: filter[0], o: @ordering == "asc" ? "desc" : "asc"), class: "ordering") %>
               <% end %>
             <% else %>
               <% if params[:q].present? %>

--- a/app/views/concerns/unwatch.js.erb
+++ b/app/views/concerns/unwatch.js.erb
@@ -1,0 +1,2 @@
+$('#watchable-toggle').replaceWith('<%= j render partial: "concerns/watchable_toggle" %>');
+setupWatchableToggleListener();

--- a/app/views/concerns/watch.js.erb
+++ b/app/views/concerns/watch.js.erb
@@ -1,0 +1,2 @@
+$('#watchable-toggle').replaceWith('<%= j render partial: "concerns/watchable_toggle" %>');
+setupWatchableToggleListener();

--- a/app/views/verifications/_comments.html.erb
+++ b/app/views/verifications/_comments.html.erb
@@ -1,0 +1,27 @@
+<hr class="spacer">
+<div class="flexbox horizontal end wrap-reverse justify-space-between">
+  <div class="verification-item flush-top flexbox vertical stretch flex-1">
+    <div class="item-title large flexbox horizontal center">
+      <span class="icon">&#xf27a;</span> Comments <%= @verification.comments.present? ? "(#{@verification.comments.count})" : '' %>
+    </div>
+    <div class="comment-list">
+      <%= render(partial: "comments/row", collection: @verification.comments, as: :comment) %>
+    </div>
+    <div class="flexbox horizontal start">
+      <%= image_tag(user_image_src(current_user, :thumb), size: "28x28", class: "commenter-avatar") %>
+      <form action="<%= comments_path %>" id="comment_box" method="POST" enctype="multipart/form-data" class="flexbox vertical end flex-1">
+        <div style="display:none">
+          <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+          <input type="hidden" id="comment_commentable_id" name="comment[commentable_id]" value="<%= @verification.id %>">
+          <input type="hidden" id="comment_commentable_type" name="comment[commentable_type]" value="Verification">
+        </div>
+        <div class="item short-bottom flexbox vertical stretch">
+          <textarea id="comment_body" name="comment[body]" class="text-field" type="text" autocomplete="off" placeholder="Add a comment"></textarea>
+        </div>
+        <div class="comment-buttons flexbox horizontal center wrap">
+          <input id="comment_submit" type="submit" class="button" value="Comment">
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/views/verifications/_related_requests.html.erb
+++ b/app/views/verifications/_related_requests.html.erb
@@ -1,0 +1,17 @@
+<hr class="spacer">
+<div class="flexbox horizontal end wrap-reverse justify-space-between">
+  <div class="pledge-item flexbox vertical stretch flex-1" style="margin-top: 0em;">
+    <div class="item-title flexbox horizontal center">
+      <span class="icon">&#xf002;</span> Related Requests <%= @related_requests.present? ? "(#{@related_requests.count})" : ''%>
+    </div>
+    <% if @related_requests.present? %>
+    <div class="item-list">
+      <%= render(partial: "verifications/row", collection: @related_requests, as: :verification) %>
+    </div>
+    <% else %>
+    <div class="item-text">
+      There are no related eligibility verification requests.
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/verifications/_row.html.erb
+++ b/app/views/verifications/_row.html.erb
@@ -16,6 +16,11 @@
         <%= Verification::STATUSES[verification.status.to_sym].upcase %>
       </div>
       <% end %>
+      <% if verification.comments.present? %>
+      <div class="commented">
+        &#xf27a;
+      </div>
+      <% end %>
       <% if verification.watched %>
       <div class="watched">
         &#xf06e;

--- a/app/views/verifications/_row.html.erb
+++ b/app/views/verifications/_row.html.erb
@@ -3,20 +3,25 @@
     <div class="row-title">
       <%= verification.full_name %>
     </div>
-    <% if verification.pending? %>
-    <div class="row-detail">
-      <%= l(verification.requested_on, format: "%b. %-d, %Y · %-l:%M%P ") %>
-    </div>
-    <% else %>
     <div class="flexbox horizontal center">
+      <% if verification.pending? %>
+      <div class="row-detail">
+        <%= l(verification.requested_on, format: "%b. %-d, %Y · %-l:%M%P ") %>
+      </div>
+      <% else %>
       <div class="row-detail">
       <%= l(verification.last_reviewed_on, format: "%b. %-d, %Y") %>&nbsp;·&nbsp;
       </div>
       <div class="row-detail <%= verification.status %>">
         <%= Verification::STATUSES[verification.status.to_sym].upcase %>
       </div>
+      <% end %>
+      <% if verification.watched %>
+      <div class="watched">
+        &#xf06e;
+      </div>
+      <% end %>
     </div>
-    <% end %>
   </div>
   <div class="flexbox horizontal center wrap justify-space-between">
     <div class="flexbox horizontal center wrap">

--- a/app/views/verifications/_show_pending.html.erb
+++ b/app/views/verifications/_show_pending.html.erb
@@ -21,3 +21,4 @@
   <%= link_to('Back', params[:back].present? ? params[:back] : verifications_path, class: "back-button mini button", tabindex: "4") %>
 </form>
 <%= render(partial: "verifications/related_requests") %>
+<%= render(partial: "verifications/comments")%>

--- a/app/views/verifications/_show_pending.html.erb
+++ b/app/views/verifications/_show_pending.html.erb
@@ -2,8 +2,11 @@
   <div class="panel-title">
     Verification Review
   </div>
-  <div class="panel-descriptor">
-    Requested <%= l(@verification.requested_on, format: "%b. %-d, %Y · %-l:%M%P") %>
+  <div class="flexbox horizontal center">
+    <div class="panel-descriptor">
+      Requested <%= l(@verification.requested_on, format: "%b. %-d, %Y · %-l:%M%P") %>
+    </div>
+    <%= render(partial: "verifications/watchable_toggle")%>
   </div>
 </div>
 <%= render(partial: "verifications/identity") %>
@@ -17,20 +20,4 @@
   <input id="ignore_submit" name="commit" type="submit" class="ignore-button button" value="Ignore" data-confirm="<%="Are you sure you want to ignore #{@verification.full_name}'s verification request?\n\nRemember, this will permanently destroy their uploaded documents and cannot be reversed 🤖" %>" tabindex="2">
   <%= link_to('Back', params[:back].present? ? params[:back] : verifications_path, class: "back-button mini button", tabindex: "4") %>
 </form>
-<hr class="spacer">
-<div class="flexbox horizontal end wrap-reverse justify-space-between">
-  <div class="pledge-item flexbox vertical stretch flex-1" style="margin-top: 0em;">
-    <div class="item-title flexbox horizontal center">
-      <span class="icon">&#xf002;</span> Related Requests <%= @related_requests.present? ? "(#{@related_requests.count})" : ''%>
-    </div>
-    <% if @related_requests.present? %>
-    <div class="item-list">
-      <%= render(partial: "verifications/row", collection: @related_requests, as: :verification) %>
-    </div>
-    <% else %>
-    <div class="item-text">
-      There are no related eligibility verification requests.
-    </div>
-    <% end %>
-  </div>
-</div>
+<%= render(partial: "verifications/related_requests") %>

--- a/app/views/verifications/_show_reviewed.html.erb
+++ b/app/views/verifications/_show_reviewed.html.erb
@@ -10,11 +10,14 @@
       Eligibility Certification
     <% end %>
   </div>
-  <div class="panel-descriptor">
-    <% if @verification.withdrawn? %>
-    Withdrawn <%= l(@verification.withdrawn_on, format: "%b. %-d, %Y · %-l:%M%P") %> [<%= link_to(@verification.withdrawer.display_name, user_path(@verification.withdrawer)) %>]<br>
-    <% end %>
-    <%= @verification.issued? ? "Issued" : Verification::STATUSES[@verification.status.to_sym].titlecase %> <%= l(@verification.reviewed_on, format: "%b. %-d, %Y · %-l:%M%P") %> [<%= link_to(@verification.reviewer.display_name, user_path(@verification.reviewer)) %>]
+  <div class="flexbox horizontal center">
+    <div class="panel-descriptor">
+      <% if @verification.withdrawn? %>
+      Withdrawn <%= l(@verification.withdrawn_on, format: "%b. %-d, %Y · %-l:%M%P") %> [<%= link_to(@verification.withdrawer.display_name, user_path(@verification.withdrawer)) %>]<br>
+      <% end %>
+      <%= @verification.issued? ? "Issued" : Verification::STATUSES[@verification.status.to_sym].titlecase %> <%= l(@verification.reviewed_on, format: "%b. %-d, %Y · %-l:%M%P") %> [<%= link_to(@verification.reviewer.display_name, user_path(@verification.reviewer)) %>]
+    </div>
+    <%= render(partial: "verifications/watchable_toggle")%>
   </div>
 </div>
 <%= render(partial: "verifications/identity") %>
@@ -34,20 +37,4 @@
     <%= link_to('Back', params[:back].present? ? params[:back] : verifications_path, class: "back-button mini button", tabindex: "1" ) %>
   </div>
 <% end %>
-<hr class="spacer">
-<div class="flexbox horizontal end wrap-reverse justify-space-between">
-  <div class="pledge-item flexbox vertical stretch flex-1" style="margin-top: 0em;">
-    <div class="item-title flexbox horizontal center">
-      <span class="icon">&#xf002;</span> Related Requests <%= @related_requests.present? ? "(#{@related_requests.count})" : ''%>
-    </div>
-    <% if @related_requests.present? %>
-    <div class="item-list">
-      <%= render(partial: "verifications/row", collection: @related_requests, as: :verification) %>
-    </div>
-    <% else %>
-    <div class="item-text">
-      There are no related eligibility verification requests.
-    </div>
-    <% end %>
-  </div>
-</div>
+<%= render(partial: "verifications/related_requests") %>

--- a/app/views/verifications/_show_reviewed.html.erb
+++ b/app/views/verifications/_show_reviewed.html.erb
@@ -38,3 +38,4 @@
   </div>
 <% end %>
 <%= render(partial: "verifications/related_requests") %>
+<%= render(partial: "verifications/comments")%>

--- a/app/views/verifications/_watchable_toggle.html.erb
+++ b/app/views/verifications/_watchable_toggle.html.erb
@@ -1,0 +1,1 @@
+<%= link_to('&#xf06e;'.html_safe, @verification.watched ? unwatch_verification_path(@verification) : watch_verification_path(@verification), id: "watchable-toggle", class: @verification.watched ? 'watched' : 'unwatched') %>

--- a/app/views/verifications/index.html.erb
+++ b/app/views/verifications/index.html.erb
@@ -19,10 +19,10 @@
           <% Verification::SORT_FILTERS.each do |filter| %>
             <% if @filter_category.to_s == filter[0].to_s %>
               <% if params[:q].present? %>
-                <%= link_to("#{filter[1]} [#{@verifications.nil? ? '0' : @verifications.count}]", verifications_path(q: params[:q], f: filter[0]), class: "filter selected") %>
+                <%= link_to("#{filter[1]} [#{@verifications.nil? ? '0' : @verifications.count}]", verifications_path(q: params[:q], f: filter[0]), class: "filter selected togglable") %>
                 <%= link_to(@ordering == "asc" ? "&#xf309;".html_safe : "&#xf30c;".html_safe, verifications_path(q: params[:q], f: filter[0], o: @ordering == "asc" ? "desc" : "asc"), class: "ordering") %>
               <% else %>
-                <%= link_to("#{filter[1]} [#{@verifications.nil? ? '0' : @verifications.count}]", verifications_path(f: filter[0]), class: "filter selected") %>
+                <%= link_to("#{filter[1]} [#{@verifications.nil? ? '0' : @verifications.count}]", verifications_path(f: filter[0]), class: "filter selected togglable") %>
                 <%= link_to(@ordering == "asc" ? "&#xf309;".html_safe : "&#xf30c;".html_safe, verifications_path(f: filter[0], o: @ordering == "asc" ? "desc" : "asc"), class: "ordering") %>
               <% end %>
             <% else %>

--- a/app/views/verifications/index.html.erb
+++ b/app/views/verifications/index.html.erb
@@ -20,8 +20,10 @@
             <% if @filter_category.to_s == filter[0].to_s %>
               <% if params[:q].present? %>
                 <%= link_to("#{filter[1]} [#{@verifications.nil? ? '0' : @verifications.count}]", verifications_path(q: params[:q], f: filter[0]), class: "filter selected") %>
+                <%= link_to(@ordering == "asc" ? "&#xf309;".html_safe : "&#xf30c;".html_safe, verifications_path(q: params[:q], f: filter[0], o: @ordering == "asc" ? "desc" : "asc"), class: "ordering") %>
               <% else %>
-                <%= link_to("#{filter[1]} [#{@verifications.nil? ? '0' : @verifications.count}]", verifications_path(f: filter[0]), class: "filter selected") %>            
+                <%= link_to("#{filter[1]} [#{@verifications.nil? ? '0' : @verifications.count}]", verifications_path(f: filter[0]), class: "filter selected") %>
+                <%= link_to(@ordering == "asc" ? "&#xf309;".html_safe : "&#xf30c;".html_safe, verifications_path(f: filter[0], o: @ordering == "asc" ? "desc" : "asc"), class: "ordering") %>
               <% end %>
             <% else %>
               <% if params[:q].present? %>

--- a/app/views/verifications/unwatch.js.erb
+++ b/app/views/verifications/unwatch.js.erb
@@ -1,0 +1,2 @@
+$('#watchable-toggle').replaceWith('<%= j render partial: "verifications/watchable_toggle" %>');
+setupWatchableToggleListener();

--- a/app/views/verifications/watch.js.erb
+++ b/app/views/verifications/watch.js.erb
@@ -1,0 +1,2 @@
+$('#watchable-toggle').replaceWith('<%= j render partial: "verifications/watchable_toggle" %>');
+setupWatchableToggleListener();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
         post :ignore
         post :withdraw
         post :resend_cert
+        post :watch
+        post :unwatch
         get  :voucher
       end
     end

--- a/db/migrate/20230810031108_add_watched_to_verifications.rb
+++ b/db/migrate/20230810031108_add_watched_to_verifications.rb
@@ -1,0 +1,5 @@
+class AddWatchedToVerifications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :verifications, :watched, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_05_014544) do
+ActiveRecord::Schema.define(version: 2023_08_10_031108) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -217,6 +217,7 @@ ActiveRecord::Schema.define(version: 2023_08_05_014544) do
     t.boolean "doctors_note_submitted", default: false
     t.datetime "withdrawn_on"
     t.integer "withdrawer_id"
+    t.boolean "watched", default: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
Updates verification system to allow moderators to watch/unwatch requests. Mods can filter verifications by watched status from the index view.

Mods can now add comments to verifications and see which verifications have comments from the index views. Mods can delete their own comments on verifications.

Related requests on verifications now have been improved to match field by field to avoid overmatching.

Mods can now toggle between ascending and descended sort order when viewing the queues for verifications or concerns. This toggle works on a per-filter basis and default to ascending (oldest at the top).


<img width="1006" alt="Verification Watchlist" src="https://github.com/AnyKeyOrg/anykey/assets/126442/bcc7e0f8-7cd4-4b3c-b626-80f0166b8ab2">
<img width="1023" alt="Verification Comments" src="https://github.com/AnyKeyOrg/anykey/assets/126442/1a7c1d4d-aa7d-4e67-acac-eca33ff3b7b1">
<img width="1023" alt="Togglable Sort Order for Verifications" src="https://github.com/AnyKeyOrg/anykey/assets/126442/24951562-b256-4e71-a263-4d44147e16f6">
<img width="1042" alt="Togglable Sort Order for Concerns" src="https://github.com/AnyKeyOrg/anykey/assets/126442/1289d776-9857-411c-8703-8488db165d3d">