### PR TITLE
Performance Optimization

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
 
   def index
-    @pledges_count = Pledge.count
+    @pledges_count = Pledge.cached_count
   end
   
 end

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -14,7 +14,7 @@ class PledgesController < ApplicationController
   def new
     @pledge = Pledge.new
     @pledges_count = Pledge.cached_count
-    @leaders = Pledge.order(referrals_count: :desc).where(badge_revoked: false).limit(10)
+    @leaders = Pledge.cached_leaders
   end
   
   def create
@@ -57,7 +57,7 @@ class PledgesController < ApplicationController
           flash.now[:alert] << message + ". "
         end
         @pledges_count = Pledge.cached_count
-        @leaders = Pledge.order(referrals_count: :desc).limit(10)
+        @leaders = Pledge.cached_leaders
         render(action: :new)
       end
     end

--- a/app/controllers/pledges_controller.rb
+++ b/app/controllers/pledges_controller.rb
@@ -13,7 +13,7 @@ class PledgesController < ApplicationController
   
   def new
     @pledge = Pledge.new
-    @pledges_count = Pledge.count
+    @pledges_count = Pledge.cached_count
     @leaders = Pledge.order(referrals_count: :desc).where(badge_revoked: false).limit(10)
   end
   
@@ -56,7 +56,7 @@ class PledgesController < ApplicationController
         @pledge.errors.full_messages.each do |message|
           flash.now[:alert] << message + ". "
         end
-        @pledges_count = Pledge.count
+        @pledges_count = Pledge.cached_count
         @leaders = Pledge.order(referrals_count: :desc).limit(10)
         render(action: :new)
       end
@@ -83,7 +83,7 @@ class PledgesController < ApplicationController
       redirect_to root_url
     
     else
-      @pledges_count = Pledge.count
+      @pledges_count = Pledge.cached_count
       cookies.delete(:pledge_redirect)
     end
   end

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -1,7 +1,11 @@
 class Pledge < ApplicationRecord
   
   before_create :ensure_signed_on_set
-    
+  
+  after_create :increment_counter
+  
+  after_destroy :decrement_counter
+  
   validates_presence_of    :first_name,
                            :last_name,
                            :email
@@ -9,15 +13,14 @@ class Pledge < ApplicationRecord
                            case_sensitive: false
   validates_format_of      :email,
                            with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/,
-                           if: lambda { |x| x.email.present? } 
-                             
+                           if: lambda { |x| x.email.present? }
   
   belongs_to :referrer, class_name: :Pledge, foreign_key: :referrer_id, optional: true
   has_many :referrals, class_name: :Pledge, foreign_key: :referrer_id
-
+  
   # Non-sequential identifier scheme   
   uniquify :identifier, length: 8, chars: ('A'..'Z').to_a + ('0'..'9').to_a
-
+  
   def to_param
     identifier
   end
@@ -30,11 +33,25 @@ class Pledge < ApplicationRecord
     end
   end
   
+  def self.cached_count
+    Rails.cache.fetch(:pledge_count, expires_in: 1.day) do
+      Pledge.count
+     end
+  end
+  
   private
     def ensure_signed_on_set
       if !self.signed_on.present?
         self.signed_on = Time.now
       end
     end
-      
+    
+    def increment_counter
+      Rails.cache.increment('pledge_count')
+    end
+    
+    def decrement_counter
+      Rails.cache.decrement('pledge_count')
+    end
+    
 end

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -39,6 +39,12 @@ class Pledge < ApplicationRecord
      end
   end
   
+  def self.cached_leaders
+    Rails.cache.fetch(:pledge_leaders, expires_in: 6.hours) do
+      Pledge.order(referrals_count: :desc).where(badge_revoked: false).limit(10)
+     end
+  end
+  
   private
     def ensure_signed_on_set
       if !self.signed_on.present?

--- a/app/views/pledges/_form.html.erb
+++ b/app/views/pledges/_form.html.erb
@@ -15,5 +15,5 @@
     <input id="pledge_email" name="pledge[email]" class="text-field" type="text" value="<%= @pledge.email %>" autocomplete="off" placeholder="bjorn@anykey.org" tabindex="3">
   </div>
   <%= display_alerts %>
-  <input id="pledge_submit" name="commit" type="submit" class="button" value="<%= t(".button") %>" tabindex="4" onsubmit="document.getElementById('pledge_submit').disabled=true;" onClick="gtag('event', 'ButtonClick', {'event_category': 'Pledge', 'event_label': 'FormSubmit'});">
+  <input id="pledge_submit" name="commit" type="submit" class="button" value="<%= t(".button") %>" tabindex="4" onClick="gtag('event', 'ButtonClick', {'event_category': 'Pledge', 'event_label': 'FormSubmit'});" data-disable-with="Pledging">
 </form>

--- a/app/views/pledges/_form.html.erb
+++ b/app/views/pledges/_form.html.erb
@@ -15,5 +15,5 @@
     <input id="pledge_email" name="pledge[email]" class="text-field" type="text" value="<%= @pledge.email %>" autocomplete="off" placeholder="bjorn@anykey.org" tabindex="3">
   </div>
   <%= display_alerts %>
-  <input id="pledge_submit" name="commit" type="submit" class="button" value="<%= t(".button") %>" tabindex="4" onClick="gtag('event', 'ButtonClick', {'event_category': 'Pledge', 'event_label': 'FormSubmit'});">
+  <input id="pledge_submit" name="commit" type="submit" class="button" value="<%= t(".button") %>" tabindex="4" onsubmit="document.getElementById('pledge_submit').disabled=true;" onClick="gtag('event', 'ButtonClick', {'event_category': 'Pledge', 'event_label': 'FormSubmit'});">
 </form>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -58,5 +58,5 @@
       <input id="report_reporter_twitch_name" name="report[reporter_twitch_name]" class="text-field" type="text" value="<%= @report.reporter_twitch_name %>" autocomplete="off" tabindex="8">
     </div>
   </div>
-  <input id="reportsubmit" name="commit" type="submit" class="button" value="Send Report" tabindex="9" onClick="gtag('event', 'ButtonClick', {'event_category': 'Report', 'event_label': 'FormSubmit'});">
+  <input id="report_submit" name="commit" type="submit" class="button" value="Send Report" tabindex="9" onClick="gtag('event', 'ButtonClick', {'event_category': 'Report', 'event_label': 'FormSubmit'});" data-disable-with="Sending">
 </form>

--- a/db/migrate/20230815032108_add_indices_to_pledges.rb
+++ b/db/migrate/20230815032108_add_indices_to_pledges.rb
@@ -1,0 +1,7 @@
+class AddIndicesToPledges < ActiveRecord::Migration[6.1]
+  def change
+    add_index :pledges, :email
+    add_index :pledges, :identifier
+    add_index :pledges, :twitch_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_10_031108) do
+ActiveRecord::Schema.define(version: 2023_08_15_032108) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -110,6 +110,9 @@ ActiveRecord::Schema.define(version: 2023_08_10_031108) do
     t.datetime "twitch_authed_on"
     t.integer "referrer_id"
     t.integer "referrals_count", default: 0
+    t.index ["email"], name: "index_pledges_on_email"
+    t.index ["identifier"], name: "index_pledges_on_identifier"
+    t.index ["twitch_id"], name: "index_pledges_on_twitch_id"
   end
 
   create_table "reports", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|


### PR DESCRIPTION
Pledge signups have dropped off and it appears to be do to the major slowdowns on queries to the pledge table which now was 1.6M+ rows. Long overdue performance optimization was necessary to mitigate the endless Pledge count(*) queries and find_by lookups. We were getting hundreds of Heroku timeout events daily so, this PR...

- Adds database index on pledge email, identifier, twitch_id for fast lookup
- Disables submit button to prevent multiples on pledge
- Disables submit button to prevent report dupes
- Stops counting pledges when /glhf loads, creates cache that increments/decrements on model events and expires daily
- Caches leaderboard list and recalculates every 6 hours