### PR TITLE
Device Logging for Pledges, Verifications, Reports, and Concerns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'devise'
 gem 'devise_invitable'
 gem 'dotenv-rails'
 gem 'pagy'
+gem 'ahoy_matey'
 
 # Using Dragonfly v0.9 for files & images
 # Because I can never get v1.0 to work with PJ's caching solution

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,10 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    ahoy_matey (5.0.2)
+      activesupport (>= 6.1)
+      device_detector (>= 1)
+      safely_block (>= 0.4)
     aliyun-sdk (0.8.0)
       nokogiri (~> 1.6)
       rest-client (~> 2.0)
@@ -101,6 +105,7 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     declarative (0.0.20)
+    device_detector (1.1.1)
     devise (4.9.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -463,6 +468,7 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
+    safely_block (0.4.0)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -508,6 +514,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  ahoy_matey
   aws-sdk-s3
   bootsnap (>= 1.4.2)
   byebug

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,0 +1,8 @@
+class Ahoy::Event < ApplicationRecord
+  include Ahoy::QueryMethods
+
+  self.table_name = "ahoy_events"
+
+  belongs_to :visit
+  belongs_to :user, optional: true
+end

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -1,0 +1,6 @@
+class Ahoy::Visit < ApplicationRecord
+  self.table_name = "ahoy_visits"
+
+  has_many :events, class_name: "Ahoy::Event"
+  belongs_to :user, optional: true
+end

--- a/app/models/concern.rb
+++ b/app/models/concern.rb
@@ -58,6 +58,9 @@ class Concern < ApplicationRecord
   
   has_many :comments, as: :commentable
   
+  # Tracks user agent info for incoming concerns
+  visitable :ahoy_visit
+  
   scope :open,         lambda { where(status: :open) }
   scope :dismissed,    lambda { where(status: :dismissed) }
   scope :reviewed,     lambda { where(status: :reviewed) }

--- a/app/models/pledge.rb
+++ b/app/models/pledge.rb
@@ -25,6 +25,9 @@ class Pledge < ApplicationRecord
   belongs_to :referrer, class_name: :Pledge, foreign_key: :referrer_id, optional: true
   has_many :referrals, class_name: :Pledge, foreign_key: :referrer_id
   
+  # Tracks user agent info for incoming pledges
+  visitable :ahoy_visit
+  
   # Non-sequential identifier scheme   
   uniquify :identifier, length: 8, chars: ('A'..'Z').to_a + ('0'..'9').to_a
   

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -41,6 +41,9 @@ class Report < ApplicationRecord
                            
   image_accessor :image
   
+  # Tracks user agent info for incoming reports
+  visitable :ahoy_visit
+  
   scope :dismissed,    lambda { where(dismissed: true) }
   scope :warned,       lambda { where(warned: true) }
   scope :revoked,      lambda { where(revoked: true) }

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -62,6 +62,9 @@ class Verification < ApplicationRecord
   
   has_many :comments, as: :commentable
   
+  # Tracks user agent info for incoming requests
+  visitable :ahoy_visit
+    
   # Non-sequential identifier scheme
   uniquify :identifier, length: 8, chars: ('A'..'Z').to_a + ('0'..'9').to_a
 

--- a/app/views/concerns/_sharer_details.html.erb
+++ b/app/views/concerns/_sharer_details.html.erb
@@ -1,0 +1,35 @@
+<hr class="spacer">
+<div class="concern-item flush-top flexbox vertical stretch flex-1">
+  <div class="item-title large flexbox horizontal center">
+    <span class="icon">&#xf109;</span> Sharer Device Details
+  </div>
+  <% unless @concern.ahoy_visit.present? %>
+  <div class="item-text large empty">
+    No device details available for this concern.
+  </div>
+  <% end %>
+</div>
+<% if @concern.ahoy_visit.present? %>
+<div class="flexbox horizontal end wrap justify-space-between">
+  <div class="concern-item half-width flexbox vertical stretch">
+    <div class="item-title">IP Address</div>
+    <div class="item-text"><%= @concern.ahoy_visit.ip %></div>
+  </div>
+  <div class="concern-item half-width flexbox vertical stretch">
+    <div class="item-title">Browser</div>
+    <div class="item-text"><%= @concern.ahoy_visit.browser %></div>
+  </div>
+  <div class="concern-item half-width flexbox vertical stretch">
+    <div class="item-title">OS</div>
+    <div class="item-text"><%= @concern.ahoy_visit.os %></div>
+  </div>
+  <div class="concern-item half-width flexbox vertical stretch">
+    <div class="item-title">Device Type</div>
+    <div class="item-text"><%= @concern.ahoy_visit.device_type %></div>
+  </div>
+  <div class="concern-item flexbox vertical stretch">
+    <div class="item-title">User Agent</div>
+    <div class="item-text small"><%= @concern.ahoy_visit.user_agent %></div>
+  </div>
+</div>
+<% end %>

--- a/app/views/concerns/_show_dismissed.html.erb
+++ b/app/views/concerns/_show_dismissed.html.erb
@@ -14,4 +14,5 @@
   <%= link_to("Undismiss", undismiss_concern_path(@concern), method: :post, class: 'undismiss-button button', tabindex: "2") %>
   <%= link_to('Back', params[:back].present? ? params[:back] : concerns_path, class: "back-button mini button", tabindex: "1") %>
 </div>
+<%= render(partial: "concerns/sharer_details")%>
 <%= render(partial: "concerns/comments")%>

--- a/app/views/concerns/_show_open.html.erb
+++ b/app/views/concerns/_show_open.html.erb
@@ -18,4 +18,5 @@
   <%= link_to("Dismiss", dismiss_concern_path(@concern), method: :post, class: 'dismiss-button button', tabindex: "3") %>
   <%= link_to('Back', params[:back].present? ? params[:back] : concerns_path, class: "back-button mini button", tabindex: "4") %>
 </form>
+<%= render(partial: "concerns/sharer_details")%>
 <%= render(partial: "concerns/comments")%>

--- a/app/views/concerns/_show_reviewed.html.erb
+++ b/app/views/concerns/_show_reviewed.html.erb
@@ -13,4 +13,5 @@
 <div class="concern-buttons flexbox horizontal-reverse wrap-reverse center">
   <%= link_to('Back', params[:back].present? ? params[:back] : concerns_path, class: "back-button mini button", tabindex: "1") %>
 </div>
+<%= render(partial: "concerns/sharer_details")%>
 <%= render(partial: "concerns/comments")%>

--- a/app/views/pledges/_pledger_details.html.erb
+++ b/app/views/pledges/_pledger_details.html.erb
@@ -1,0 +1,35 @@
+<hr class="spacer">
+<div class="pledge-item flush-top flexbox vertical stretch flex-1">
+  <div class="item-title large flexbox horizontal center">
+    <span class="icon">&#xf109;</span> Pledger Device Details
+  </div>
+  <% unless @pledge.ahoy_visit.present? %>
+  <div class="item-text large empty">
+    No device details available for this pledge.
+  </div>
+  <% end %>
+</div>
+<% if @pledge.ahoy_visit.present? %>
+<div class="flexbox horizontal end wrap justify-space-between">
+  <div class="pledge-item half-width flexbox vertical stretch">
+    <div class="item-title">IP Address</div>
+    <div class="item-text"><%= @pledge.ahoy_visit.ip %></div>
+  </div>
+  <div class="pledge-item half-width flexbox vertical stretch">
+    <div class="item-title">Browser</div>
+    <div class="item-text"><%= @pledge.ahoy_visit.browser %></div>
+  </div>
+  <div class="pledge-item half-width flexbox vertical stretch">
+    <div class="item-title">OS</div>
+    <div class="item-text"><%= @pledge.ahoy_visit.os %></div>
+  </div>
+  <div class="pledge-item half-width flexbox vertical stretch">
+    <div class="item-title">Device Type</div>
+    <div class="item-text"><%= @pledge.ahoy_visit.device_type %></div>
+  </div>
+  <div class="pledge-item flexbox vertical stretch">
+    <div class="item-title">User Agent</div>
+    <div class="item-text small"><%= @pledge.ahoy_visit.user_agent %></div>
+  </div>
+</div>
+<% end %>

--- a/app/views/pledges/staff_show.html.erb
+++ b/app/views/pledges/staff_show.html.erb
@@ -11,6 +11,7 @@
       <div class="pledge-buttons flexbox horizontal-reverse wrap-reverse center">
         <%= link_to('Back', params[:back].present? ? params[:back] : staff_index_path, class: "back-button mini button", tabindex: "1") %>
       </div>
+      <%= render(partial: "pledges/pledger_details") %>
       <%= render(partial: "pledges/reports_about") %>
       <%= render(partial: "pledges/reports_filed") %>
       <%= render(partial: "pledges/referrals") %>

--- a/app/views/reports/_reporter_details.html.erb
+++ b/app/views/reports/_reporter_details.html.erb
@@ -1,0 +1,35 @@
+<hr class="spacer">
+<div class="report-item flush-top flexbox vertical stretch flex-1">
+  <div class="item-title large flexbox horizontal center">
+    <span class="icon">&#xf109;</span> Reporter Device Details
+  </div>
+  <% unless @report.ahoy_visit.present? %>
+  <div class="item-text large empty">
+    No device details available for this report.
+  </div>
+  <% end %>
+</div>
+<% if @report.ahoy_visit.present? %>
+<div class="flexbox horizontal end wrap justify-space-between">
+  <div class="report-item half-width flexbox vertical stretch">
+    <div class="item-title">IP Address</div>
+    <div class="item-text"><%= @report.ahoy_visit.ip %></div>
+  </div>
+  <div class="report-item half-width flexbox vertical stretch">
+    <div class="item-title">Browser</div>
+    <div class="item-text"><%= @report.ahoy_visit.browser %></div>
+  </div>
+  <div class="report-item half-width flexbox vertical stretch">
+    <div class="item-title">OS</div>
+    <div class="item-text"><%= @report.ahoy_visit.os %></div>
+  </div>
+  <div class="report-item half-width flexbox vertical stretch">
+    <div class="item-title">Device Type</div>
+    <div class="item-text"><%= @report.ahoy_visit.device_type %></div>
+  </div>
+  <div class="report-item flexbox vertical stretch">
+    <div class="item-title">User Agent</div>
+    <div class="item-text small"><%= @report.ahoy_visit.user_agent %></div>
+  </div>
+</div>
+<% end %>

--- a/app/views/reports/_show_dismissed.html.erb
+++ b/app/views/reports/_show_dismissed.html.erb
@@ -14,5 +14,6 @@
   <%= link_to("Undismiss", undismiss_report_path(@report), method: :post, class: 'undismiss-button button') %>
   <%= link_to('Back', params[:back].present? ? params[:back] : reports_path, class: "back-button mini button") %>
 </div>
+<%= render(partial: "reports/reporter_details") %>
 <%= render(partial: "reports/related_reports") %>
 <%= render(partial: "reports/comments")%>

--- a/app/views/reports/_show_revoked.html.erb
+++ b/app/views/reports/_show_revoked.html.erb
@@ -20,5 +20,6 @@
   <div class="revoked-button button">Revoked</div>
   <%= link_to('Back', params[:back].present? ? params[:back] : reports_path, class: "back-button mini button") %>
 </div>
+<%= render(partial: "reports/reporter_details") %>
 <%= render(partial: "reports/related_reports") %>
 <%= render(partial: "reports/comments")%>

--- a/app/views/reports/_show_unresolved.html.erb
+++ b/app/views/reports/_show_unresolved.html.erb
@@ -18,5 +18,6 @@
   <%= link_to("Dismiss", dismiss_report_path(@report), method: :post, class: 'dismiss-button button') %>
   <%= link_to('Back', params[:back].present? ? params[:back] : reports_path, class: "back-button mini button") %>
 </div>
+<%= render(partial: "reports/reporter_details") %>
 <%= render(partial: "reports/related_reports") %>
 <%= render(partial: "reports/comments")%>

--- a/app/views/reports/_show_warned.html.erb
+++ b/app/views/reports/_show_warned.html.erb
@@ -20,5 +20,6 @@
   <div class="warned-button button">Warned</div>
   <%= link_to('Back', params[:back].present? ? params[:back] : reports_path, class: "back-button mini button") %>
 </div>
+<%= render(partial: "reports/reporter_details") %>
 <%= render(partial: "reports/related_reports") %>
 <%= render(partial: "reports/comments")%>

--- a/app/views/verifications/_requester_details.html.erb
+++ b/app/views/verifications/_requester_details.html.erb
@@ -1,10 +1,15 @@
 <hr class="spacer">
-<% if @verification.ahoy_visit.present? %>
 <div class="verification-item flush-top flexbox vertical stretch flex-1">
   <div class="item-title large flexbox horizontal center">
     <span class="icon">&#xf109;</span> Requester Device Details
   </div>
+  <% unless @verification.ahoy_visit.present? %>
+  <div class="item-text large empty">
+    No device details available for this request.
+  </div>
+  <% end %>
 </div>
+<% if @verification.ahoy_visit.present? %>
 <div class="flexbox horizontal end wrap justify-space-between">
   <div class="verification-item half-width flexbox vertical stretch">
     <div class="item-title">IP Address</div>
@@ -25,16 +30,6 @@
   <div class="verification-item flexbox vertical stretch">
     <div class="item-title">User Agent</div>
     <div class="item-text small"><%= @verification.ahoy_visit.user_agent %></div>
-  </div>  
-</div>
-<% else %>
-<div class="verification-item flush-top flexbox vertical stretch flex-1">
-  <div class="item-title large flexbox horizontal center">
-    <span class="icon">&#xf109;</span> Requester Device Details
-  </div>
-  <div class="item-text large empty">
-    No device details available for this request.
   </div>
 </div>
 <% end %>
-

--- a/app/views/verifications/_requester_details.html.erb
+++ b/app/views/verifications/_requester_details.html.erb
@@ -1,0 +1,40 @@
+<hr class="spacer">
+<% if @verification.ahoy_visit.present? %>
+<div class="verification-item flush-top flexbox vertical stretch flex-1">
+  <div class="item-title large flexbox horizontal center">
+    <span class="icon">&#xf109;</span> Requester Device Details
+  </div>
+</div>
+<div class="flexbox horizontal end wrap justify-space-between">
+  <div class="verification-item half-width flexbox vertical stretch">
+    <div class="item-title">IP Address</div>
+    <div class="item-text"><%= @verification.ahoy_visit.ip %></div>
+  </div>
+  <div class="verification-item half-width flexbox vertical stretch">
+    <div class="item-title">Browser</div>
+    <div class="item-text"><%= @verification.ahoy_visit.browser %></div>
+  </div>
+  <div class="verification-item half-width flexbox vertical stretch">
+    <div class="item-title">OS</div>
+    <div class="item-text"><%= @verification.ahoy_visit.os %></div>
+  </div>
+  <div class="verification-item half-width flexbox vertical stretch">
+    <div class="item-title">Device Type</div>
+    <div class="item-text"><%= @verification.ahoy_visit.device_type %></div>
+  </div>
+  <div class="verification-item flexbox vertical stretch">
+    <div class="item-title">User Agent</div>
+    <div class="item-text small"><%= @verification.ahoy_visit.user_agent %></div>
+  </div>  
+</div>
+<% else %>
+<div class="verification-item flush-top flexbox vertical stretch flex-1">
+  <div class="item-title large flexbox horizontal center">
+    <span class="icon">&#xf109;</span> Requester Device Details
+  </div>
+  <div class="item-text large empty">
+    No device details available for this request.
+  </div>
+</div>
+<% end %>
+

--- a/app/views/verifications/_show_pending.html.erb
+++ b/app/views/verifications/_show_pending.html.erb
@@ -20,5 +20,6 @@
   <input id="ignore_submit" name="commit" type="submit" class="ignore-button button" value="Ignore" data-confirm="<%="Are you sure you want to ignore #{@verification.full_name}'s verification request?\n\nRemember, this will permanently destroy their uploaded documents and cannot be reversed 🤖" %>" tabindex="2">
   <%= link_to('Back', params[:back].present? ? params[:back] : verifications_path, class: "back-button mini button", tabindex: "4") %>
 </form>
+<%= render(partial: "verifications/requester_details") %>
 <%= render(partial: "verifications/related_requests") %>
 <%= render(partial: "verifications/comments")%>

--- a/app/views/verifications/_show_reviewed.html.erb
+++ b/app/views/verifications/_show_reviewed.html.erb
@@ -37,5 +37,6 @@
     <%= link_to('Back', params[:back].present? ? params[:back] : verifications_path, class: "back-button mini button", tabindex: "1" ) %>
   </div>
 <% end %>
+<%= render(partial: "verifications/requester_details") %>
 <%= render(partial: "verifications/related_requests") %>
 <%= render(partial: "verifications/comments")%>

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,0 +1,10 @@
+class Ahoy::Store < Ahoy::DatabaseStore
+end
+
+# set to true for JavaScript tracking
+Ahoy.api = false
+
+# set to true for geocoding (and add the geocoder gem to your Gemfile)
+# we recommend configuring local geocoding as well
+# see https://github.com/ankane/ahoy#geocoding
+Ahoy.geocode = false

--- a/db/migrate/20231011175659_create_ahoy_visits_and_events.rb
+++ b/db/migrate/20231011175659_create_ahoy_visits_and_events.rb
@@ -1,0 +1,61 @@
+class CreateAhoyVisitsAndEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ahoy_visits do |t|
+      t.string :visit_token
+      t.string :visitor_token
+
+      # the rest are recommended but optional
+      # simply remove any you don't want
+
+      # user
+      t.references :user
+
+      # standard
+      t.string :ip
+      t.text :user_agent
+      t.text :referrer
+      t.string :referring_domain
+      t.text :landing_page
+
+      # technology
+      t.string :browser
+      t.string :os
+      t.string :device_type
+
+      # location
+      t.string :country
+      t.string :region
+      t.string :city
+      t.float :latitude
+      t.float :longitude
+
+      # utm parameters
+      t.string :utm_source
+      t.string :utm_medium
+      t.string :utm_term
+      t.string :utm_content
+      t.string :utm_campaign
+
+      # native apps
+      # t.string :app_version
+      # t.string :os_version
+      # t.string :platform
+
+      t.datetime :started_at
+    end
+
+    add_index :ahoy_visits, :visit_token, unique: true
+    add_index :ahoy_visits, [:visitor_token, :started_at]
+
+    create_table :ahoy_events do |t|
+      t.references :visit
+      t.references :user
+
+      t.string :name
+      t.json :properties
+      t.datetime :time
+    end
+
+    add_index :ahoy_events, [:name, :time]
+  end
+end

--- a/db/migrate/20231012175536_add_ahoy_visit_to_verifications.rb
+++ b/db/migrate/20231012175536_add_ahoy_visit_to_verifications.rb
@@ -1,0 +1,5 @@
+class AddAhoyVisitToVerifications < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :verifications, :ahoy_visit
+  end
+end

--- a/db/migrate/20231016193526_add_ahoy_visit_to_pledges.rb
+++ b/db/migrate/20231016193526_add_ahoy_visit_to_pledges.rb
@@ -1,0 +1,5 @@
+class AddAhoyVisitToPledges < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :pledges, :ahoy_visit
+  end
+end

--- a/db/migrate/20231016193533_add_ahoy_visit_to_reports.rb
+++ b/db/migrate/20231016193533_add_ahoy_visit_to_reports.rb
@@ -1,0 +1,5 @@
+class AddAhoyVisitToReports < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :reports, :ahoy_visit
+  end
+end

--- a/db/migrate/20231016193538_add_ahoy_visit_to_concerns.rb
+++ b/db/migrate/20231016193538_add_ahoy_visit_to_concerns.rb
@@ -1,0 +1,5 @@
+class AddAhoyVisitToConcerns < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :concerns, :ahoy_visit
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_12_175536) do
+ActiveRecord::Schema.define(version: 2023_10_16_193538) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -132,6 +132,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_175536) do
     t.integer "reviewer_id"
     t.integer "comments_count", default: 0
     t.integer "screenshots_submitted_count", default: 0
+    t.bigint "ahoy_visit_id"
+    t.index ["ahoy_visit_id"], name: "index_concerns_on_ahoy_visit_id"
   end
 
   create_table "conduct_warnings", charset: "utf8mb4", collation: "utf8mb4_unicode_520_ci", force: :cascade do |t|
@@ -160,6 +162,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_175536) do
     t.datetime "twitch_authed_on"
     t.integer "referrer_id"
     t.integer "referrals_count", default: 0
+    t.bigint "ahoy_visit_id"
+    t.index ["ahoy_visit_id"], name: "index_pledges_on_ahoy_visit_id"
     t.index ["email"], name: "index_pledges_on_email"
     t.index ["identifier"], name: "index_pledges_on_identifier"
     t.index ["twitch_id"], name: "index_pledges_on_twitch_id"
@@ -185,6 +189,8 @@ ActiveRecord::Schema.define(version: 2023_10_12_175536) do
     t.integer "reporter_twitch_id"
     t.integer "reported_twitch_id"
     t.integer "incident_stream_twitch_id"
+    t.bigint "ahoy_visit_id"
+    t.index ["ahoy_visit_id"], name: "index_reports_on_ahoy_visit_id"
     t.index ["reported_twitch_id"], name: "index_reports_on_reported_twitch_id"
     t.index ["reporter_email"], name: "index_reports_on_reporter_email"
     t.index ["reporter_twitch_id"], name: "index_reports_on_reporter_twitch_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_17_210212) do
+ActiveRecord::Schema.define(version: 2023_10_12_175536) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -55,6 +55,45 @@ ActiveRecord::Schema.define(version: 2023_08_17_210212) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "discord"
     t.string "mixer"
+  end
+
+  create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "visit_id"
+    t.bigint "user_id"
+    t.string "name"
+    t.json "properties"
+    t.datetime "time"
+    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["user_id"], name: "index_ahoy_events_on_user_id"
+    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
+  end
+
+  create_table "ahoy_visits", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "visit_token"
+    t.string "visitor_token"
+    t.bigint "user_id"
+    t.string "ip"
+    t.text "user_agent"
+    t.text "referrer"
+    t.string "referring_domain"
+    t.text "landing_page"
+    t.string "browser"
+    t.string "os"
+    t.string "device_type"
+    t.string "country"
+    t.string "region"
+    t.string "city"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "utm_source"
+    t.string "utm_medium"
+    t.string "utm_term"
+    t.string "utm_content"
+    t.string "utm_campaign"
+    t.datetime "started_at"
+    t.index ["user_id"], name: "index_ahoy_visits_on_user_id"
+    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
+    t.index ["visitor_token", "started_at"], name: "index_ahoy_visits_on_visitor_token_and_started_at"
   end
 
   create_table "badge_activations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -241,6 +280,8 @@ ActiveRecord::Schema.define(version: 2023_08_17_210212) do
     t.integer "withdrawer_id"
     t.boolean "watched", default: false
     t.integer "comments_count", default: 0
+    t.bigint "ahoy_visit_id"
+    t.index ["ahoy_visit_id"], name: "index_verifications_on_ahoy_visit_id"
     t.index ["identifier"], name: "index_verifications_on_identifier"
   end
 


### PR DESCRIPTION
This PR introduces the Ahoy gem to lay the foundation for first-party analytics. In this initial phase, we begin logging visit information for all incoming requests and we associate those visits with new pledges, verifications, reports, and concerns. On the staff review pages, mods can now see IP address, device type, operating system, browser, and user agent information for each new request.