### PR TITLE
Batch withdrawal

### DIFF
--- a/lib/tasks/batch_withdrawal.rake
+++ b/lib/tasks/batch_withdrawal.rake
@@ -25,7 +25,7 @@ namespace :verifications do
           puts "#{cert_code} cannot be withdrawn, it does not exist"
           # Cert code xyz does not exist
         elsif verification.withdrawn?
-          puts "#{cert_code} cannot be withdrawn, it already was"
+          puts "#{cert_code} cannot be withdrawn, it was already"
         elsif verification.denied? || verification.ignored?
           puts "#{cert_code} cannot be withdrawn, it was #{verification.status}"
         elsif verification.pending?

--- a/lib/tasks/batch_withdrawal.rake
+++ b/lib/tasks/batch_withdrawal.rake
@@ -1,0 +1,46 @@
+# This task queitly withdraws a batch of certificates from a CSV file using STDIN
+# It will work on Heroku as well as in development
+# Local usage: rake verifications:batch_withdrawal < /local/path/to/cert_batch.csv
+# Remote usage: heroku run rake verifications:batch_withdrawal < /local/path/to/cert_batch.csv
+
+namespace :verifications do
+
+  desc "Quietly withdraws batch of eligibility certificates (without sending notification emails)"
+
+  task :batch_withdrawal, [:filename] => :environment do |task, args|
+
+    require 'csv'
+
+    puts "Beginning batch certificate withdrawal..."
+
+    # Ingest relevant data from batch csv file
+    CSV.parse(STDIN.read, headers: true).each do |row|
+      item = row.to_hash.symbolize_keys
+      
+      unless item[:certificate_code].blank?
+        cert_code = item[:certificate_code].upcase
+        verification = Verification.find_by(identifier: cert_code)
+
+        if verification.blank?
+          puts "#{cert_code} cannot be withdrawn, it does not exist"
+          # Cert code xyz does not exist
+        elsif verification.withdrawn?
+          puts "#{cert_code} cannot be withdrawn, it already was"
+        elsif verification.denied? || verification.ignored?
+          puts "#{cert_code} cannot be withdrawn, it was #{verification.status}"
+        elsif verification.pending?
+          puts "#{cert_code} cannot be withdrawn, it is pending"
+        elsif verification.eligible?
+          if verification.update(status: :withdrawn, refusal_reason: "Quietly withdrawn in batch cleanup.", withdrawer: User.first, withdrawn_on: Time.now)
+            puts "#{cert_code} was quietly withdrawn"
+          else
+            puts "#{cert_code} could not be withdrawn, something went wrong"
+          end
+        end
+      end
+    end
+    
+    puts "Process complete."
+    
+  end
+end

--- a/lib/tasks/validate_certificates.rake
+++ b/lib/tasks/validate_certificates.rake
@@ -1,4 +1,4 @@
-# This task imports past pledges from a CSV file using STDIN
+# This task validates eligibility for a batch of certificates from a CSV file using STDIN
 # It will work on Heroku as well as in development
 # Local usage: rake verifications:validate_certificates < /local/path/to/player_data.csv
 # Remote usage: heroku run rake verifications:validate_certificates --no-tty < /local/path/to/player_data.csv > /local/path/for/results.csv


### PR DESCRIPTION
Provides a rake task for quietly withdrawing a batch of eligibility certificates. This function was requested by the ComfyCrew in order to bring our database in line with the current policy of withdrawing old certificates when new ones are created at the request of a player changing their details.