### PR TITLE
Survey invitation system for admin use

### DIFF
--- a/app/mailers/survey_invite_mailer.rb
+++ b/app/mailers/survey_invite_mailer.rb
@@ -1,0 +1,10 @@
+class SurveyInviteMailer < ApplicationMailer
+  
+  default from: DO_NOT_REPLY
+  
+  def send_invitation(survey_invite)
+    @survey_invite = survey_invite
+    mail(to: survey_invite.email, subject: "Invitation to participate in the #{SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym]} #{survey_invite.survey_title}")
+  end
+  
+end

--- a/app/models/survey_invite.rb
+++ b/app/models/survey_invite.rb
@@ -21,8 +21,12 @@ class SurveyInvite < ApplicationRecord
   
   uniquify :survey_code, length: 6, chars: ('A'..'Z').to_a + ('0'..'9').to_a
 
+
+  # Google Form pre-fille links look like:
+  # https://docs.google.com/forms/IDENTIFIER/viewform?usp=pp_url&entry.IDNUMBER=DATA
+  # Admins should provide the full link apart from DATA as the survey_url
   def url_with_code
-    self.survey_url+'?code='+self.survey_code
+    self.survey_url+self.survey_code
   end
 
 end

--- a/app/models/survey_invite.rb
+++ b/app/models/survey_invite.rb
@@ -1,0 +1,28 @@
+class SurveyInvite < ApplicationRecord
+  
+  SURVEYABLE_TYPES = {
+    verification:  "Verification",
+    pledge:        "Pledge",
+    report:        "Report",
+    concern:       "Concern"
+  }.freeze
+  
+  SURVEYABLE_SYSTEMS = {
+    verification:  "Eligibility Certification System",
+    pledge:        "GLHF Pledge",
+    report:        "GLHF Pledge Report System",
+    concern:       "Competitor Concern System"
+  }.freeze
+  
+  validates_presence_of  :email,
+                         :surveyable_type,
+                         :survey_title,
+                         :survey_url
+  
+  uniquify :survey_code, length: 6, chars: ('A'..'Z').to_a + ('0'..'9').to_a
+
+  def url_with_code
+    self.survey_url+'?code='+self.survey_code
+  end
+
+end

--- a/app/models/survey_invite.rb
+++ b/app/models/survey_invite.rb
@@ -23,8 +23,8 @@ class SurveyInvite < ApplicationRecord
 
 
   # Google Form pre-fille links look like:
-  # https://docs.google.com/forms/IDENTIFIER/viewform?usp=pp_url&entry.IDNUMBER=DATA
-  # Admins should provide the full link apart from DATA as the survey_url
+  # https://docs.google.com/forms/<IDENTIFIER>/viewform?usp=pp_url&entry.<ID>=<survey_code>
+  # Admins should provide the full link apart from survey_code as the survey_url
   def url_with_code
     self.survey_url+self.survey_code
   end

--- a/app/views/survey_invite_mailer/send_invitation.html.erb
+++ b/app/views/survey_invite_mailer/send_invitation.html.erb
@@ -4,7 +4,7 @@ We are continually working to improve our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@
 <br><br>
 Please take our <%= link_to(@survey_invite.survey_title, @survey_invite.url_with_code) %> to share your perspective about our system and weigh in on changes we are considering.
 <br><br>
-Participate using your unique code <strong><%= @survey_invite.survey_code %></strong> by visiting: <%= link_to(@survey_invite.url_with_code, @survey_invite.url_with_code) %>
+You can participate using code <strong><%= @survey_invite.survey_code %></strong> by visiting this: <%= link_to("unique survey link", @survey_invite.url_with_code) %>
 <br><br>
 If you have any questions to ask or further information to share, please drop by the #support-lounge in our <%= link_to("Discord server", "https://discord.gg/Vpn8QQzTtS") %> to start a ModMail conversation with us.
 <br><br>

--- a/app/views/survey_invite_mailer/send_invitation.html.erb
+++ b/app/views/survey_invite_mailer/send_invitation.html.erb
@@ -1,0 +1,11 @@
+Hey <%= @survey_invite.email.gsub(/\@.*/,"") %>,
+<br><br>
+We are continually working to improve our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym] %> based on feedback from the community. Today we are inviting you to give us direct input.
+<br><br>
+Please take our <%= link_to(@survey_invite.survey_title, @survey_invite.url_with_code) %> to share your perspective about our system and weigh in on changes we are considering.
+<br><br>
+Participate using your unique code <strong><%= @survey_invite.survey_code %></strong> by visiting: <%= link_to(@survey_invite.url_with_code, @survey_invite.url_with_code) %>
+<br><br>
+If you have any questions to ask or further information to share, please drop by the #support-lounge in our <%= link_to("Discord server", "https://discord.gg/Vpn8QQzTtS") %> to start a ModMail conversation with us.
+<br><br>
+The AnyKey team looks forwarding to hearing from you - GLHF!

--- a/app/views/survey_invite_mailer/send_invitation.text.erb
+++ b/app/views/survey_invite_mailer/send_invitation.text.erb
@@ -4,7 +4,7 @@ We are continually working to improve our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@
 
 Please take our <%= @survey_invite.survey_title %> to share your perspective about our system and weigh in on changes we are considering.
 
-Participate using your unique code <%= @survey_invite.survey_code %> by visiting: <%= @survey_invite.url_with_code %>
+You can participate using code <%= @survey_invite.survey_code %> by visiting this unique survey link: <%= @survey_invite.url_with_code %>
 
 If you have any questions to ask or further information to share, please drop by the #support-lounge in our Discord server (https://discord.gg/Vpn8QQzTtS) to start a ModMail conversation with us.
 

--- a/app/views/survey_invite_mailer/send_invitation.text.erb
+++ b/app/views/survey_invite_mailer/send_invitation.text.erb
@@ -1,0 +1,11 @@
+Hey <%= @survey_invite.email.gsub(/\@.*/,"") %>,
+
+We are continually working to improve our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym] %> and today we want to hear from you directly.
+
+Please take our <%= @survey_invite.survey_title %> to share your perspective about our system and weigh in on changes we are considering.
+
+Participate using your unique code <%= @survey_invite.survey_code %> by visiting: <%= @survey_invite.url_with_code %>
+
+If you have any questions to ask or further information to share, please drop by the #support-lounge in our Discord server (https://discord.gg/Vpn8QQzTtS) to start a ModMail conversation with us.
+
+The AnyKey team looks forwarding to hearing from you - GLHF!

--- a/app/views/survey_invite_mailer/send_invitation.text.erb
+++ b/app/views/survey_invite_mailer/send_invitation.text.erb
@@ -1,6 +1,6 @@
 Hey <%= @survey_invite.email.gsub(/\@.*/,"") %>,
 
-We are continually working to improve our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym] %> and today we want to hear from you directly.
+We are continually working to improve our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym] %> based on feedback from the community. Today we are inviting you to give us direct input.
 
 Please take our <%= @survey_invite.survey_title %> to share your perspective about our system and weigh in on changes we are considering.
 

--- a/db/migrate/20231103174246_create_survey_invites.rb
+++ b/db/migrate/20231103174246_create_survey_invites.rb
@@ -1,0 +1,14 @@
+class CreateSurveyInvites < ActiveRecord::Migration[6.1]
+  def change
+    create_table :survey_invites do |t|
+      t.string :email
+      t.string :survey_code
+      t.string :surveyable_type
+      t.string :survey_title
+      t.string :survey_url
+      t.datetime :sent_on
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_16_205711) do
+ActiveRecord::Schema.define(version: 2023_11_03_174246) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -216,6 +216,17 @@ ActiveRecord::Schema.define(version: 2023_10_16_205711) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "published", default: false
     t.datetime "published_on"
+  end
+
+  create_table "survey_invites", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email"
+    t.string "survey_code"
+    t.string "surveyable_type"
+    t.string "survey_title"
+    t.string "survey_url"
+    t.datetime "sent_on"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "twitch_tokens", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/lib/tasks/batch_invitation.rake
+++ b/lib/tasks/batch_invitation.rake
@@ -1,0 +1,79 @@
+# This task sends a batch of survey invitations to all the eligible participants
+# Determined using the criteria found in a JSON file ingested via STDIN
+# It will work on Heroku as well as in development
+# Local usage: rake survey_invites:batch_invitation < /local/path/to/survey_params.json
+# Remote usage: heroku run rake survey_invites:batch_invitation --no-tty < /local/path/to/survey_params.json
+
+# JSON file should include single hash with the following params:
+# "surveyable_type": e.g. Verification, Pledge, Report, Concern
+# "surveyable_criteria": e.g. where('created_at >= ? AND created_at < ?', Time.now.beginning_of_year, Time.now.end_of_year).order(created_at: :desc)
+# "survey_title": e.g. 2020 Year End
+# "survey_url": e.g. https://forms.gle/12345678
+
+namespace :survey_invites do
+
+  desc "Determines eligible participants and sends batch of survey invitations"
+
+  task :batch_invitation, [:filename] => :environment do |task, args|
+
+    require 'json'
+    require 'uri'
+    
+    puts "Determining eligible participants..."
+
+    survey_params = JSON.parse(STDIN.read).symbolize_keys
+
+    # Gentle checks ensures admin does not accidentally create nonsenical/destructive chain of commands
+    if survey_params[:surveyable_type].blank?
+      puts "ERORR: `surveyable_type` cannot be blank. Process halting."
+    elsif !["Verification", "Pledge", "Report", "Concern"].map {|t| t == survey_params[:surveyable_type] }.include?(true) 
+      puts "ERORR: `surveyable_type` is not valid. Process halting."  
+    elsif survey_params[:surveyable_criteria].blank?
+      puts "ERORR: `surveyable_criteria` cannot be blank. Process halting."
+    elsif !survey_params[:surveyable_criteria].start_with?("where")
+      puts "ERORR: `surveyable_criteria` must begin with `where`. Process halting."
+    elsif survey_params[:survey_title].blank?
+      puts "ERORR: `survey_title` cannot be blank. Process halting."
+    elsif survey_params[:survey_url].blank?
+      puts "ERORR: `survey_url` cannot be blank. Process halting."
+    elsif !valid_url?(survey_params[:survey_url])
+      puts "ERORR: `survey_url` must be a valid URL. Process halting."
+    else
+      participants = eval "#{survey_params[:surveyable_type]}.#{survey_params[:surveyable_criteria]}" 
+
+      emails = participants.pluck(:email).uniq
+      
+      puts "#{participants.count} #{survey_params[:surveyable_type].downcase.pluralize} matched the criteria"
+      
+      puts "#{emails.count} unique email addresses identified"
+
+      puts emails
+      
+      puts "Sending batch of invitations..."
+    
+      emails.each do |email|
+        survey_invite = SurveyInvite.new(email: email,
+                                         surveyable_type: survey_params[:surveyable_type],
+                                         survey_title: survey_params[:survey_title],
+                                         survey_url: survey_params[:survey_url],
+                                         sent_on: Time.now)
+        if survey_invite.save        
+          SurveyInviteMailer.send_invitation(survey_invite).deliver_now
+          puts "Sent survey invite to #{survey_invite.email}"
+        else
+          puts "Something went wrong creating the invite for #{email}"
+        end  
+      end
+      
+      puts "Process complete."
+    end
+  end
+
+  def valid_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) && !uri.host.nil?
+  rescue URI::InvalidURIError
+    false
+  end
+  
+end

--- a/lib/tasks/batch_invitation.rake
+++ b/lib/tasks/batch_invitation.rake
@@ -8,7 +8,8 @@
 # "surveyable_type": e.g. Verification, Pledge, Report, Concern
 # "surveyable_criteria": e.g. where('created_at >= ? AND created_at < ?', Time.now.beginning_of_year, Time.now.end_of_year).order(created_at: :desc)
 # "survey_title": e.g. 2020 Year End
-# "survey_url": e.g. https://forms.gle/12345678
+# "survey_url": e.g. https://docs.google.com/forms/<IDENTIFIER>/viewform?usp=pp_url&entry.<ID>=<survey_code>
+# Note: that everything but the survey_code we generate should be included in
 
 namespace :survey_invites do
 

--- a/lib/tasks/batch_withdrawal.rake
+++ b/lib/tasks/batch_withdrawal.rake
@@ -37,6 +37,8 @@ namespace :verifications do
         elsif verification.pending?
           puts "#{cert_code} cannot be withdrawn, it is pending"
         elsif verification.eligible?
+          # TODO: silence SQL query output here
+          # Or... remove from response using RegEx: ^.*?D,.*?$\n
           if verification.update(status: :withdrawn, refusal_reason: "Quietly withdrawn in batch cleanup.", withdrawer: User.first, withdrawn_on: Time.now)
             puts "#{cert_code} was quietly withdrawn"
           else

--- a/test/fixtures/survey_invites.yml
+++ b/test/fixtures/survey_invites.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: MyString
+  survey_code: MyString
+  surveyable_type: MyString
+  survey_title: MyString
+  survey_url: MyString
+  sent_on: 2023-11-03 13:42:46
+
+two:
+  email: MyString
+  survey_code: MyString
+  surveyable_type: MyString
+  survey_title: MyString
+  survey_url: MyString
+  sent_on: 2023-11-03 13:42:46

--- a/test/mailers/previews/survey_invite_mailer_preview.rb
+++ b/test/mailers/previews/survey_invite_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/survey_invite_mailer
+class SurveyInviteMailerPreview < ActionMailer::Preview
+  def send_invitation
+    SurveyInviteMailer.send_invitation(SurveyInvite.last)
+  end
+end

--- a/test/mailers/survey_invite_mailer_test.rb
+++ b/test/mailers/survey_invite_mailer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SurveyInviteMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/survey_invite_test.rb
+++ b/test/models/survey_invite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SurveyInviteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Introduces new Survey Invite feature that allows admins to generate and send a batch of invitation emails to users of a "surveyable" record (Verifications, Pledges, Reports, and Concerns) that match given criteria.

The task requires a JSON file formatted as:
```
{
  "surveyable_type": "Pledge",
  "surveyable_criteria": "where('created_at >= ? AND created_at < ?', Time.now.beginning_of_year, Time.now.end_of_year).order(created_at: :desc)",
  "survey_title": "2020 Year End",
  "survey_url": "https://docs.google.com/forms/<IDENTIFIER>/viewform?usp=pp_url&entry.<ID>=<survey_code>"
}
```
The rake task has gentle checks to ensure that admins do not accidentally create nonsenical/destructive requests.

<img width="1060" alt="batch_invitation errors and success (2023-11-6)" src="https://github.com/AnyKeyOrg/anykey/assets/126442/25ed1c2c-ed96-478f-a97e-8d4f62d3ab4d">

<img width="1051" alt="survey invitation email (2023-11-6)" src="https://github.com/AnyKeyOrg/anykey/assets/126442/b225eb60-b847-4555-bc43-829d7e02a5d3">
