### PR TITLE
Survey reminders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,6 +511,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/mailers/survey_invite_mailer.rb
+++ b/app/mailers/survey_invite_mailer.rb
@@ -7,4 +7,9 @@ class SurveyInviteMailer < ApplicationMailer
     mail(to: survey_invite.email, subject: "Invitation to participate in the #{SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym]} #{survey_invite.survey_title}")
   end
   
+  def send_reminder(survey_invite)
+    @survey_invite = survey_invite
+    mail(to: survey_invite.email, subject: "Reminder to participate in the #{SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym]} #{survey_invite.survey_title}")
+  end
+
 end

--- a/app/views/survey_invite_mailer/send_reminder.html.erb
+++ b/app/views/survey_invite_mailer/send_reminder.html.erb
@@ -1,0 +1,7 @@
+Hey <%= @survey_invite.email.gsub(/\@.*/,"") %>,
+<br><br>
+Just a friendly reminder that we hope you will share your feedback on our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym] %> in the <%= link_to(@survey_invite.survey_title, @survey_invite.url_with_code) %>.
+<br><br>
+Please participate using code <strong><%= @survey_invite.survey_code %></strong> by visiting this: <%= link_to("unique survey link", @survey_invite.url_with_code) %>
+<br><br>
+The AnyKey team values your input - GLHF!

--- a/app/views/survey_invite_mailer/send_reminder.text.erb
+++ b/app/views/survey_invite_mailer/send_reminder.text.erb
@@ -1,0 +1,7 @@
+Hey <%= @survey_invite.email.gsub(/\@.*/,"") %>,
+
+Just a friendly reminder that we hope you will share your feedback on our <%= SurveyInvite::SURVEYABLE_SYSTEMS[@survey_invite.surveyable_type.downcase.to_sym] %> in the <%= @survey_invite.survey_title %>.
+
+Please participate using code <%= @survey_invite.survey_code %> by visiting this unique survey link: <%= @survey_invite.url_with_code %>
+
+The AnyKey team values your input - GLHF!

--- a/app/views/verifications/_form.html.erb
+++ b/app/views/verifications/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="flexbox horizontal wrap justify-space-between">
     <div class="item half-width flexbox vertical stretch">
       <label for="first_name" class="text-field">First Name</label>
-      <input id="verification_first_name" name="verification[first_name]" class="text-field" type="text" value="<%= @verification.first_name %>" autocomplete="off"  tabindex="1">
+      <input id="verification_first_name" name="verification[first_name]" class="text-field" type="text" value="<%= @verification.first_name %>" autocomplete="off" required tabindex="1">
     </div>
     <div class="item half-width flexbox vertical stretch">
       <label for="last_name" class="text-field">Last Name</label>

--- a/lib/tasks/batch_invitation.rake
+++ b/lib/tasks/batch_invitation.rake
@@ -28,19 +28,19 @@ namespace :survey_invites do
 
       # Gentle checks ensures admin does not accidentally create nonsenical/destructive chain of commands
       if survey_params[:surveyable_type].blank?
-        puts "ERORR: `surveyable_type` cannot be blank. Process halting."
+        puts "ERROR: `surveyable_type` cannot be blank. Process halting."
       elsif !["Verification", "Pledge", "Report", "Concern"].map {|t| t == survey_params[:surveyable_type] }.include?(true)
-        puts "ERORR: `surveyable_type` is not valid. Process halting."
+        puts "ERROR: `surveyable_type` is not valid. Process halting."
       elsif survey_params[:surveyable_criteria].blank?
-        puts "ERORR: `surveyable_criteria` cannot be blank. Process halting."
+        puts "ERROR: `surveyable_criteria` cannot be blank. Process halting."
       elsif !survey_params[:surveyable_criteria].start_with?("where")
-        puts "ERORR: `surveyable_criteria` must begin with `where`. Process halting."
+        puts "ERROR: `surveyable_criteria` must begin with `where`. Process halting."
       elsif survey_params[:survey_title].blank?
-        puts "ERORR: `survey_title` cannot be blank. Process halting."
+        puts "ERROR: `survey_title` cannot be blank. Process halting."
       elsif survey_params[:survey_url].blank?
-        puts "ERORR: `survey_url` cannot be blank. Process halting."
+        puts "ERROR: `survey_url` cannot be blank. Process halting."
       elsif !valid_url?(survey_params[:survey_url])
-        puts "ERORR: `survey_url` must be a valid URL. Process halting."
+        puts "ERROR: `survey_url` must be a valid URL. Process halting."
       else
         participants = eval "#{survey_params[:surveyable_type]}.#{survey_params[:surveyable_criteria]}"
 

--- a/lib/tasks/batch_reminder.rake
+++ b/lib/tasks/batch_reminder.rake
@@ -1,0 +1,40 @@
+# This task sends a batch of reminders for previously generated survey invitations
+# Sends reminders to list of survey codes ingested from a CSV file via STDIN
+# It will work on Heroku as well as in development
+# Local usage: rake survey_invites:batch_reminder < /local/path/to/survey_codes.csv
+# Remote usage: heroku run rake survey_invites:batch_reminder --no-tty < /local/path/to/survey_codes.csv
+
+namespace :survey_invites do
+
+  desc "Determines eligible participants and sends batch of survey invitations"
+
+  task :batch_reminder, [:filename] => :environment do |task, args|
+
+    require 'csv'
+
+    # Silences output of SQL queries when run on Heroku
+    Rails.logger.silence do
+      
+      # Ingest relevant data from batch csv file
+      CSV.parse(STDIN.read, headers: true).each do |row|
+      
+        survey_code = row.to_hash.symbolize_keys[:survey_code]
+        
+        if survey_code.blank?
+          puts "ERROR: survey_code cannot be blank"
+        else
+          survey_invite = SurveyInvite.find_by(survey_code: survey_code)
+                    
+          if survey_invite.blank?
+            puts "ERROR: survey_code '#{survey_code}' does not exist"
+          else
+            puts "Found invitation with survey_code '#{survey_code}', generating reminder..."
+            SurveyInviteMailer.send_reminder(survey_invite).deliver_now
+            puts "Sent reminder to #{survey_invite.email}"
+          end
+        end
+      end
+      
+    end
+  end
+end

--- a/test/mailers/previews/survey_invite_mailer_preview.rb
+++ b/test/mailers/previews/survey_invite_mailer_preview.rb
@@ -3,4 +3,7 @@ class SurveyInviteMailerPreview < ActionMailer::Preview
   def send_invitation
     SurveyInviteMailer.send_invitation(SurveyInvite.last)
   end
+  def send_reminder
+    SurveyInviteMailer.send_reminder(SurveyInvite.last)
+  end
 end


### PR DESCRIPTION
Lightweight feature that allows dev to send a batch of reminders about survey invitations.

Ingests lists of survey_codes to send reminders to vis csv. Sends short email to all those that are found.

![Screenshot 2023-12-04 at 4 23 27 PM](https://github.com/AnyKeyOrg/anykey/assets/126442/37b7b4bd-1756-4217-930c-2bb5aae871aa)

![Screenshot 2023-12-04 at 3 33 09 PM](https://github.com/AnyKeyOrg/anykey/assets/126442/ead9902a-1191-4c0e-a541-4d57388ab56b)
